### PR TITLE
DASH: Log the sensors_wrapper_activate lock/unlocks as verbose

### DIFF
--- a/sensors_wrapper.c
+++ b/sensors_wrapper.c
@@ -31,12 +31,12 @@
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
 #define LOCK(p) do { \
-	ALOGD("%s(%d): %s: lock\n", __FILE__, __LINE__, __func__); \
+	ALOGV("%s(%d): %s: lock\n", __FILE__, __LINE__, __func__); \
 	pthread_mutex_lock(p); \
 } while (0)
 
 #define UNLOCK(p) do { \
-	ALOGD("%s(%d): %s: unlock\n", __FILE__, __LINE__, __func__); \
+	ALOGV("%s(%d): %s: unlock\n", __FILE__, __LINE__, __func__); \
 	pthread_mutex_unlock(p); \
 } while (0)
 


### PR DESCRIPTION
- Avoid the excessive log spam with :
  sensors_wrapper_set_delay: unlock
  sensors_wrapper_set_delay: lock
  sensors_wrapper_set_delay: unlock
  sensors_wrapper_activate: lock

Change-Id: If46a528727ed0450449f2aeb9499a1c2d0eab160
